### PR TITLE
Python 3 compatibility fix for pickle.

### DIFF
--- a/gpnn/reader/gpnn_reader.py
+++ b/gpnn/reader/gpnn_reader.py
@@ -1,11 +1,11 @@
 import os
 import numpy as np
-import cPickle as pickle
 from scipy import sparse
 from scipy.sparse import vstack
 
 from gpnn.factory import ReaderFactory
 from gpnn.data.gpnn_data import GPNNData
+from gpnn.utils import gpnn_pickle as pickle
 from gpnn.utils.logger import get_logger
 from gpnn.utils.preprocess_diel import load_sparse_csr, read_cites, read_sim_dict
 from gpnn.utils.reader_helper import read_idx_file

--- a/gpnn/reader/gpnn_reader_custom.py
+++ b/gpnn/reader/gpnn_reader_custom.py
@@ -1,11 +1,11 @@
 import os
 import numpy as np
-import cPickle as pickle
 from scipy import sparse
 
 from gpnn.factory import ReaderFactory
 from gpnn.data.gpnn_data import GPNNData
 from gpnn.reader.gpnn_reader import GPNNReader
+from gpnn.utils import gpnn_pickle as pickle
 from gpnn.utils.logger import get_logger
 
 logger = get_logger()

--- a/gpnn/runner/planetoid_runner.py
+++ b/gpnn/runner/planetoid_runner.py
@@ -4,7 +4,6 @@ import os
 import json
 import numpy as np
 import tensorflow as tf
-import cPickle as pickle
 from collections import defaultdict
 
 from gpnn.factory import RunnerFactory

--- a/gpnn/utils/gpnn_pickle.py
+++ b/gpnn/utils/gpnn_pickle.py
@@ -1,0 +1,15 @@
+# A compatability wrapper for the pickle module. cPickle was removed
+# in Python 3.
+
+try:
+  import cPickle as pickle
+except ModuleNotFoundError:
+  import pickle
+
+
+def load(*args, **kwargs):
+  return pickle.load(*args, **kwargs)
+
+
+def dump(*args, **kwargs):
+  return pickle.dump(*args, **kwargs)

--- a/gpnn/utils/preprocess_diel.py
+++ b/gpnn/utils/preprocess_diel.py
@@ -4,9 +4,9 @@
 import os
 import argparse
 import numpy as np
-import cPickle as pickle
 from scipy import sparse
 from collections import defaultdict as dd
+from gpnn.utils import gpnn_pickle as pickle
 from gpnn.utils.logger import get_logger
 
 logger = get_logger()


### PR DESCRIPTION
`cPickle` was removed in Python 3.x, so add our own pickle module which will work with either module.

There may be other Python 3.x issues, this was the first I found. Is there a test suite?